### PR TITLE
Add paramter for gifs pop-up

### DIFF
--- a/talos/TALOS.ini
+++ b/talos/TALOS.ini
@@ -23,6 +23,7 @@ Highlanders_List = Error Manager
 Personal_Log = 
 GUI_Skins = 
 Project_INI = CIRCUS.ini
+schedule_gifs = False
 
 
 [ERRORS]


### PR DESCRIPTION
Added a new paramter in the TALOS.ini file to switch on/off whether the gifs in the Scheduler should be shown when scheduling the schedules